### PR TITLE
Remove exportWithOriginalSigningIdentity option

### DIFF
--- a/tasks/xcode.js
+++ b/tasks/xcode.js
@@ -177,7 +177,6 @@ module.exports = function(grunt) {
       if(options.exportProvisioningProfile) command.push('-exportProvisioningProfile', safelyWrap(options.exportProvisioningProfile));
       if(options.exportSigningIdentity) command.push('-exportSigningIdentity', safelyWrap(options.exportSigningIdentity));
       if(options.exportInstallerIdentity) command.push('-exportInstallerIdentity', safelyWrap(options.exportInstallerIdentity));
-      if(!options.exportSigningIdentity) command.push('-exportWithOriginalSigningIdentity');
 
       grunt.log.write('Exporting: ');
       return executeCommand(command)


### PR DESCRIPTION
Im noobie at iOS so its probably completely wrong ;D

i've got error

```
xcodebuild: error: The flag -exportWithOriginalSigningIdentity cannot be specified along with an explicit signing identity.
```

after removing `exportWithOriginalSigningIdentity` flag, build succeed
